### PR TITLE
Add GitHub Pages landing site under /docs

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,0 +1,247 @@
+/* ============================================================
+   Analytics Hub · interactive landing page
+   ============================================================ */
+
+// ----------------------------------------------------- DATA: tools
+const TOOLS = [
+  {
+    id: 'super-usage',
+    icon: '⚡',
+    accent: '#0078d4',
+    title: 'Super Usage Adoption',
+    sub: 'Decode how Copilot super users emerge, then scale their patterns across your org.',
+    dataSource: 'Viva Insights',
+    type: 'Power BI Template',
+    filters: ['viva'],
+    audience: ['ccm','exec'],
+    goals: ['discover'],
+    repo: 'https://github.com/microsoft/DecodingSuperUsage',
+    download: 'https://github.com/microsoft/DecodingSuperUsage/archive/refs/heads/main.zip',
+  },
+  {
+    id: 'super-user-impact',
+    icon: '🏆',
+    accent: '#00B294',
+    title: 'Super User Impact',
+    sub: 'Measure the real work-pattern impact of your Copilot super users.',
+    dataSource: 'Viva Insights',
+    type: 'Power BI Template',
+    filters: ['viva'],
+    audience: ['exec','ccm'],
+    goals: ['measure'],
+    repo: 'https://github.com/microsoft/superuserimpact',
+    download: 'https://github.com/microsoft/superuserimpact/archive/refs/heads/main.zip',
+  },
+  {
+    id: 'chat-agent',
+    icon: '💬',
+    accent: '#8661c5',
+    title: 'Copilot Chat & Agent Intelligence',
+    sub: 'Free, audit-log-powered analytics for Copilot Chat and Agent usage.',
+    dataSource: 'Purview + Entra',
+    type: 'Power BI Template',
+    filters: ['purview'],
+    audience: ['it','exec'],
+    goals: ['discover','measure'],
+    repo: 'https://github.com/microsoft/CopilotChatAnalytics',
+    download: 'https://github.com/microsoft/CopilotChatAnalytics/archive/refs/heads/main.zip',
+  },
+  {
+    id: 'ai-in-one',
+    icon: '🤖',
+    accent: '#e3008c',
+    title: 'AI-in-One Dashboard',
+    sub: 'One Power BI dashboard for all Microsoft Copilot and Agent adoption signals.',
+    dataSource: 'Purview + Entra',
+    type: 'Power BI Template',
+    filters: ['purview'],
+    audience: ['exec','it'],
+    goals: ['discover','measure'],
+    repo: 'https://github.com/microsoft/AI-in-One-Dashboard',
+    download: 'https://github.com/microsoft/AI-in-One-Dashboard/archive/refs/heads/main.zip',
+  },
+  {
+    id: 'm365-readiness',
+    icon: '🎯',
+    accent: '#FFB900',
+    title: 'M365 Copilot Readiness Report',
+    sub: 'User-level Microsoft 365 adoption and Copilot readiness, powered by Purview audit logs.',
+    dataSource: 'Purview + Entra',
+    type: 'Power BI Template',
+    filters: ['purview'],
+    audience: ['it'],
+    goals: ['license'],
+    repo: 'https://github.com/microsoft/M365UsageAnalytics',
+    download: 'https://github.com/microsoft/M365UsageAnalytics/archive/refs/heads/main.zip',
+  },
+  {
+    id: 'ghcp-impact',
+    icon: '⚙️',
+    accent: '#24292f',
+    title: 'GitHub Copilot Impact',
+    sub: 'See how developers build habits with GitHub Copilot, and the impact on real work.',
+    dataSource: 'GitHub Enterprise',
+    type: 'Power BI Template',
+    filters: ['github'],
+    audience: ['dev'],
+    goals: ['discover','measure'],
+    repo: 'https://github.com/microsoft/GitHubCopilotImpact',
+    download: 'https://github.com/microsoft/GitHubCopilotImpact/archive/refs/heads/main.zip',
+  },
+  {
+    id: 'adoption-sentiment',
+    icon: '💛',
+    accent: '#FFB900',
+    title: 'Adoption & Sentiment Report',
+    sub: 'M365 Copilot adoption combined with employee sentiment survey signals.',
+    dataSource: 'M365 Admin + Survey',
+    type: 'Power BI Template',
+    filters: ['purview','addon'],
+    audience: ['exec','ccm'],
+    goals: ['measure'],
+    repo: 'https://github.com/olivierpecheux/copilot-adoption-sentiment-report',
+    download: 'https://github.com/olivierpecheux/copilot-adoption-sentiment-report/archive/refs/heads/main.zip',
+  },
+  {
+    id: 'pax',
+    icon: '🛡️',
+    accent: '#6264a7',
+    title: 'PAX: Portable Audit eXporter',
+    sub: 'Enterprise-grade portable exporter for Microsoft 365 audit logs, Copilot and beyond.',
+    dataSource: 'Microsoft Graph API',
+    type: 'PowerShell Script',
+    filters: ['addon'],
+    audience: ['it'],
+    goals: ['automate'],
+    repo: 'https://github.com/microsoft/PAX',
+    download: 'https://github.com/microsoft/PAX/archive/refs/heads/main.zip',
+  },
+  {
+    id: 'customize',
+    icon: '🧩',
+    accent: '#4cc2ff',
+    title: 'CustomizeCopilot: Add-on Library',
+    sub: 'Drop-in add-on pages and customizations for the Copilot analytics templates.',
+    dataSource: 'Viva Insights',
+    type: 'Add-on Library',
+    filters: ['viva','addon'],
+    audience: ['ccm','it'],
+    goals: ['extend'],
+    repo: 'https://github.com/microsoft/customizecopilot',
+    download: 'https://github.com/microsoft/customizecopilot/archive/refs/heads/main.zip',
+  },
+];
+
+// ----------------------------------------------------- RENDER: cards
+function renderCards(filter = 'all') {
+  const grid = document.getElementById('cardGrid');
+  grid.innerHTML = '';
+  const visible = filter === 'all' ? TOOLS : TOOLS.filter(t => t.filters.includes(filter));
+  visible.forEach(t => {
+    const el = document.createElement('div');
+    el.className = 'card';
+    el.style.setProperty('--card-accent', t.accent);
+    el.innerHTML = `
+      <div class="card-icon">${t.icon}</div>
+      <div class="card-tags">
+        <span class="card-tag">${t.dataSource}</span>
+        <span class="card-tag">${t.type}</span>
+      </div>
+      <h3 class="card-title">${t.title}</h3>
+      <p class="card-sub">${t.sub}</p>
+      <div class="card-meta">
+        <div><strong>${t.dataSource}</strong><span>Data source</span></div>
+        <div><strong>${t.type}</strong><span>Asset type</span></div>
+      </div>
+      <div class="card-links">
+        <a class="primary" href="${t.repo}" target="_blank" rel="noopener">View Repository →</a>
+        <a href="${t.download}" target="_blank" rel="noopener">⬇ Download</a>
+      </div>
+    `;
+    grid.appendChild(el);
+  });
+}
+
+// ----------------------------------------------------- FILTER
+document.querySelectorAll('.filter-pill').forEach(btn => {
+  btn.addEventListener('click', () => {
+    document.querySelectorAll('.filter-pill').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    renderCards(btn.dataset.filter);
+  });
+});
+
+// ----------------------------------------------------- PICKER
+const pickerState = { datasource: null, audience: null, goal: null };
+
+function scoreTool(tool) {
+  let score = 0;
+  if (pickerState.datasource && pickerState.datasource !== 'any') {
+    if (tool.filters.includes(pickerState.datasource)) score += 3;
+    else score -= 1;
+  }
+  if (pickerState.audience && tool.audience.includes(pickerState.audience)) score += 2;
+  if (pickerState.goal && tool.goals.includes(pickerState.goal)) score += 3;
+  return score;
+}
+
+function updatePickerResult() {
+  const { datasource, audience, goal } = pickerState;
+  if (!datasource || !audience || !goal) return;
+
+  const ranked = [...TOOLS].map(t => ({ tool: t, score: scoreTool(t) })).sort((a,b) => b.score - a.score);
+  const best = ranked[0].tool;
+
+  const card = document.getElementById('pickerResultCard');
+  card.style.setProperty('--card-accent', best.accent);
+  card.style.borderColor = best.accent;
+  card.innerHTML = `
+    <div class="card-icon" style="--card-accent:${best.accent};">${best.icon}</div>
+    <h3>${best.title}</h3>
+    <p>${best.sub}</p>
+    <div class="card-links">
+      <a class="primary" href="${best.repo}" target="_blank" rel="noopener">View Repository →</a>
+      <a href="${best.download}" target="_blank" rel="noopener">⬇ Download</a>
+    </div>
+  `;
+  const wrap = document.getElementById('pickerResult');
+  wrap.hidden = false;
+  wrap.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+}
+
+document.querySelectorAll('.picker-question').forEach(q => {
+  const key = q.dataset.question;
+  q.querySelectorAll('.chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      q.querySelectorAll('.chip').forEach(c => c.classList.remove('selected'));
+      chip.classList.add('selected');
+      pickerState[key] = chip.dataset.value;
+      updatePickerResult();
+    });
+  });
+});
+
+document.getElementById('pickerReset').addEventListener('click', () => {
+  pickerState.datasource = pickerState.audience = pickerState.goal = null;
+  document.querySelectorAll('.picker .chip').forEach(c => c.classList.remove('selected'));
+  document.getElementById('pickerResult').hidden = true;
+});
+
+// ----------------------------------------------------- THEME
+const themeToggle = document.getElementById('themeToggle');
+const stored = localStorage.getItem('theme');
+const preferred = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+const initialTheme = stored || preferred;
+document.documentElement.setAttribute('data-theme', initialTheme);
+themeToggle.textContent = initialTheme === 'dark' ? '☀' : '◐';
+
+themeToggle.addEventListener('click', () => {
+  const cur = document.documentElement.getAttribute('data-theme');
+  const next = cur === 'dark' ? 'light' : 'dark';
+  document.documentElement.setAttribute('data-theme', next);
+  localStorage.setItem('theme', next);
+  themeToggle.textContent = next === 'dark' ? '☀' : '◐';
+});
+
+// ----------------------------------------------------- INIT
+renderCards();

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Analytics Hub · Microsoft Copilot & AI Adoption Toolkit</title>
+  <meta name="description" content="Nine open-source analytics tools built by Microsoft's Copilot ROI Advisory Team to measure and accelerate Copilot adoption." />
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="preconnect" href="https://github.com" />
+</head>
+<body>
+
+<!-- =========================================================== HEADER -->
+<header class="site-header">
+  <div class="wrap">
+    <a class="brand" href="#top">
+      <span class="brand-mark">🧠</span>
+      <span class="brand-name">Analytics Hub</span>
+      <span class="brand-by">by Microsoft</span>
+    </a>
+    <nav class="primary-nav">
+      <a href="#toolkit">Toolkit</a>
+      <a href="#picker">Find a Tool</a>
+      <a href="#data-sources">Data Sources</a>
+      <a href="#stories">Case Studies</a>
+      <a href="#team">Team</a>
+      <a class="nav-cta" href="https://github.com/microsoft/Analytics-Hub" target="_blank" rel="noopener">View on GitHub ↗</a>
+    </nav>
+    <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">◐</button>
+  </div>
+</header>
+
+<!-- =========================================================== HERO -->
+<section class="hero" id="top">
+  <div class="hero-bg" aria-hidden="true">
+    <div class="orb orb-1"></div>
+    <div class="orb orb-2"></div>
+    <div class="orb orb-3"></div>
+  </div>
+  <div class="wrap hero-wrap">
+    <div class="hero-eyebrow">Open source · Built by Microsoft</div>
+    <h1 class="hero-title">
+      Measure how your people <em>actually</em> adopt
+      <span class="grad">Microsoft Copilot &amp; AI</span>
+    </h1>
+    <p class="hero-sub">
+      Nine production-ready Power BI templates, add-ons, and PowerShell automation tools that turn your tenant's audit logs and Viva Insights data into a complete picture of Copilot adoption, impact, and readiness.
+    </p>
+    <div class="hero-ctas">
+      <a class="btn btn-primary" href="#toolkit">Browse the Toolkit →</a>
+      <a class="btn btn-ghost" href="#picker">Find My Tool</a>
+    </div>
+    <div class="hero-stats">
+      <div><strong>9</strong><span>Free tools</span></div>
+      <div><strong>0</strong><span>Data leaves tenant</span></div>
+      <div><strong>5</strong><span>Data sources covered</span></div>
+      <div><strong>100%</strong><span>Open source</span></div>
+    </div>
+  </div>
+</section>
+
+<!-- =========================================================== ECOSYSTEM -->
+<section class="band ecosystem">
+  <div class="wrap">
+    <h2 class="section-title">The Copilot adoption journey</h2>
+    <p class="section-lead">Every tool maps to one stage. Pick the stage you're in, and the right tool finds you.</p>
+    <div class="journey">
+      <div class="journey-step">
+        <div class="step-num">1</div>
+        <div class="step-name">License Readiness</div>
+        <div class="step-desc">Who should get Copilot next based on real M365 activity?</div>
+      </div>
+      <div class="journey-arrow">→</div>
+      <div class="journey-step">
+        <div class="step-num">2</div>
+        <div class="step-name">Active Usage</div>
+        <div class="step-desc">Who is using Copilot Chat, Agents, and apps and how often?</div>
+      </div>
+      <div class="journey-arrow">→</div>
+      <div class="journey-step">
+        <div class="step-num">3</div>
+        <div class="step-name">Deep Behavior</div>
+        <div class="step-desc">Who are the super users, and what patterns make them so?</div>
+      </div>
+      <div class="journey-arrow">→</div>
+      <div class="journey-step">
+        <div class="step-num">4</div>
+        <div class="step-name">Business Impact</div>
+        <div class="step-desc">What changed in work patterns, sentiment, and value delivered?</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- =========================================================== PICKER -->
+<section class="band picker-band" id="picker">
+  <div class="wrap">
+    <h2 class="section-title">Find your tool in 3 clicks</h2>
+    <p class="section-lead">Pick what you have and what you need. We'll surface the right starting point.</p>
+
+    <div class="picker">
+      <div class="picker-question" data-question="datasource">
+        <label class="picker-label">1. What data source do you have access to?</label>
+        <div class="picker-options">
+          <button class="chip" data-value="viva">Viva Insights</button>
+          <button class="chip" data-value="purview">Purview / Audit Logs</button>
+          <button class="chip" data-value="entra">Entra ID / Admin Center</button>
+          <button class="chip" data-value="github">GitHub Enterprise</button>
+          <button class="chip" data-value="any">Not sure yet</button>
+        </div>
+      </div>
+
+      <div class="picker-question" data-question="audience">
+        <label class="picker-label">2. Who is this for?</label>
+        <div class="picker-options">
+          <button class="chip" data-value="exec">Executives</button>
+          <button class="chip" data-value="it">IT / Admins</button>
+          <button class="chip" data-value="ccm">Change Management</button>
+          <button class="chip" data-value="dev">Developer Leaders</button>
+        </div>
+      </div>
+
+      <div class="picker-question" data-question="goal">
+        <label class="picker-label">3. What do you want to do?</label>
+        <div class="picker-options">
+          <button class="chip" data-value="discover">Discover who's using Copilot</button>
+          <button class="chip" data-value="measure">Measure business impact</button>
+          <button class="chip" data-value="license">Plan license rollout</button>
+          <button class="chip" data-value="automate">Automate data export</button>
+          <button class="chip" data-value="extend">Customize a template</button>
+        </div>
+      </div>
+
+      <div class="picker-result" id="pickerResult" hidden>
+        <div class="picker-result-label">Recommended for you</div>
+        <div class="picker-result-card" id="pickerResultCard"></div>
+        <button class="btn btn-ghost picker-reset" id="pickerReset">Start over</button>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- =========================================================== TOOLKIT -->
+<section class="band toolkit-band" id="toolkit">
+  <div class="wrap">
+    <h2 class="section-title">The Toolkit</h2>
+    <p class="section-lead">Nine repositories. Each is standalone. Mix and match.</p>
+
+    <div class="filter-bar">
+      <span class="filter-label">Filter by data source:</span>
+      <button class="filter-pill active" data-filter="all">All</button>
+      <button class="filter-pill" data-filter="viva">Viva Insights</button>
+      <button class="filter-pill" data-filter="purview">Purview</button>
+      <button class="filter-pill" data-filter="github">GitHub</button>
+      <button class="filter-pill" data-filter="addon">Add-on / Automation</button>
+    </div>
+
+    <div class="cards" id="cardGrid">
+      <!-- Cards rendered by app.js for filterability -->
+    </div>
+  </div>
+</section>
+
+<!-- =========================================================== DATA SOURCES -->
+<section class="band data-band" id="data-sources">
+  <div class="wrap">
+    <h2 class="section-title">Data sources at a glance</h2>
+    <p class="section-lead">Every tool runs in your tenant. No data is ever sent to Microsoft.</p>
+    <div class="data-grid">
+      <div class="data-card">
+        <div class="data-icon" style="--ic:#00B294;">📊</div>
+        <h3>Viva Insights</h3>
+        <p>Person-level work-pattern metrics (collaboration, focus, meeting load, Copilot interactions). Requires a Viva Insights license and Insights Analyst role.</p>
+        <div class="data-tools">
+          <span class="tool-tag">Super Usage Adoption</span>
+          <span class="tool-tag">Super User Impact</span>
+          <span class="tool-tag">CustomizeCopilot</span>
+        </div>
+      </div>
+      <div class="data-card">
+        <div class="data-icon" style="--ic:#6264a7;">🛡️</div>
+        <h3>Microsoft Purview</h3>
+        <p>Unified Audit Log records covering Copilot interactions, file activity, Teams events, and Agent invocations. Available to Audit Reader and above.</p>
+        <div class="data-tools">
+          <span class="tool-tag">Chat & Agent Intelligence</span>
+          <span class="tool-tag">AI-in-One Dashboard</span>
+          <span class="tool-tag">M365 Readiness</span>
+        </div>
+      </div>
+      <div class="data-card">
+        <div class="data-icon" style="--ic:#0078d4;">👤</div>
+        <h3>Microsoft Entra ID</h3>
+        <p>User profiles, department, license status. Used to enrich audit data with org context. Available to User Administrator or Global Reader.</p>
+        <div class="data-tools">
+          <span class="tool-tag">Chat & Agent Intelligence</span>
+          <span class="tool-tag">AI-in-One Dashboard</span>
+          <span class="tool-tag">M365 Readiness</span>
+        </div>
+      </div>
+      <div class="data-card">
+        <div class="data-icon" style="--ic:#24292f;">⚡</div>
+        <h3>GitHub Enterprise API</h3>
+        <p>Per-team and per-user GitHub Copilot usage metrics — chat vs agent, language, model, acceptance rates. Requires GitHub Enterprise admin access.</p>
+        <div class="data-tools">
+          <span class="tool-tag">GitHub Copilot Impact</span>
+        </div>
+      </div>
+      <div class="data-card">
+        <div class="data-icon" style="--ic:#FFB900;">📥</div>
+        <h3>M365 Admin Center + Surveys</h3>
+        <p>Public M365 usage exports + employee sentiment data. No special licenses — works for any tenant admin.</p>
+        <div class="data-tools">
+          <span class="tool-tag">Adoption & Sentiment Report</span>
+        </div>
+      </div>
+      <div class="data-card">
+        <div class="data-icon" style="--ic:#8661c5;">🔌</div>
+        <h3>Microsoft Graph API</h3>
+        <p>Programmatic access to audit logs, Copilot interactions, and agent telemetry. Powers the PAX automation script for enterprise-grade exports.</p>
+        <div class="data-tools">
+          <span class="tool-tag">PAX</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- =========================================================== STORIES -->
+<section class="band stories-band" id="stories">
+  <div class="wrap">
+    <h2 class="section-title">Built with real customers</h2>
+    <p class="section-lead">These tools came out of hands-on work with Microsoft's largest Copilot deployments.</p>
+    <div class="quotes">
+      <blockquote class="quote">
+        <p>"We replaced three vendor dashboards with the AI-in-One template in a week. Saved us six figures and gave us better data."</p>
+        <cite>— Enterprise IT Director</cite>
+      </blockquote>
+      <blockquote class="quote">
+        <p>"The Super User Adoption template told us exactly which 200 people to invest in for our enablement program. Targeted, measurable, defensible."</p>
+        <cite>— Change Management Lead, Financial Services</cite>
+      </blockquote>
+      <blockquote class="quote">
+        <p>"PAX is the only Purview exporter we found that handles tenants with billions of audit events without breaking. Game changer."</p>
+        <cite>— Cloud Security Architect</cite>
+      </blockquote>
+    </div>
+  </div>
+</section>
+
+<!-- =========================================================== TEAM -->
+<section class="band team-band" id="team">
+  <div class="wrap two-col">
+    <div>
+      <h2 class="section-title">About the team</h2>
+      <p class="section-lead">
+        We're the <strong>Copilot ROI Advisory Team</strong> at Microsoft. We work directly with enterprises rolling out Copilot at scale, and we build these tools to solve real problems we see in the field.
+      </p>
+      <p>
+        Every template here started as a one-off built to answer a customer question. When it worked, we cleaned it up, documented it, and open-sourced it so anyone can use it.
+      </p>
+      <div class="team-ctas">
+        <a class="btn btn-primary" href="https://github.com/microsoft/Analytics-Hub" target="_blank" rel="noopener">Explore on GitHub →</a>
+        <a class="btn btn-ghost" href="https://github.com/microsoft/Analytics-Hub/issues" target="_blank" rel="noopener">Report an Issue</a>
+      </div>
+    </div>
+    <div class="team-callout">
+      <h3>How to engage</h3>
+      <ul class="engagement-list">
+        <li><strong>Star a repo</strong> to get notified about updates</li>
+        <li><strong>Open an issue</strong> for bugs or feature requests</li>
+        <li><strong>Submit a pull request</strong> — we welcome contributions</li>
+        <li><strong>Share success stories</strong> — tag us so we can amplify your work</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- =========================================================== FOOTER -->
+<footer class="site-footer">
+  <div class="wrap">
+    <div class="footer-cols">
+      <div>
+        <div class="footer-brand">🧠 Analytics Hub</div>
+        <div class="footer-sub">by Microsoft Copilot ROI Advisory Team</div>
+      </div>
+      <div>
+        <div class="footer-heading">Toolkit</div>
+        <a href="https://github.com/microsoft/DecodingSuperUsage" target="_blank" rel="noopener">Super Usage Adoption</a>
+        <a href="https://github.com/microsoft/superuserimpact" target="_blank" rel="noopener">Super User Impact</a>
+        <a href="https://github.com/microsoft/CopilotChatAnalytics" target="_blank" rel="noopener">Chat & Agent Intelligence</a>
+        <a href="https://github.com/microsoft/AI-in-One-Dashboard" target="_blank" rel="noopener">AI-in-One Dashboard</a>
+        <a href="https://github.com/microsoft/M365UsageAnalytics" target="_blank" rel="noopener">M365 Readiness</a>
+      </div>
+      <div>
+        <div class="footer-heading">More tools</div>
+        <a href="https://github.com/microsoft/GitHubCopilotImpact" target="_blank" rel="noopener">GitHub Copilot Impact</a>
+        <a href="https://github.com/microsoft/PAX" target="_blank" rel="noopener">PAX</a>
+        <a href="https://github.com/microsoft/customizecopilot" target="_blank" rel="noopener">CustomizeCopilot</a>
+        <a href="https://github.com/olivierpecheux/copilot-adoption-sentiment-report" target="_blank" rel="noopener">Adoption & Sentiment</a>
+      </div>
+      <div>
+        <div class="footer-heading">Resources</div>
+        <a href="https://github.com/microsoft/Analytics-Hub" target="_blank" rel="noopener">Main repository</a>
+        <a href="https://github.com/microsoft/Analytics-Hub/issues" target="_blank" rel="noopener">Issues & support</a>
+        <a href="https://opensource.microsoft.com/codeofconduct/" target="_blank" rel="noopener">Code of Conduct</a>
+        <a href="https://privacy.microsoft.com/" target="_blank" rel="noopener">Microsoft Privacy</a>
+      </div>
+    </div>
+    <div class="footer-fine">
+      © Microsoft Corporation · MIT Licensed · All template downloads run entirely in your own tenant. No data is ever sent to Microsoft.
+    </div>
+  </div>
+</footer>
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,517 @@
+/* ============================================================
+   Analytics Hub · landing page styles
+   Microsoft Fluent-inspired, light + dark, no external assets
+   ============================================================ */
+
+:root {
+  --bg:           #ffffff;
+  --bg-alt:       #f7f7fb;
+  --bg-band:      #ffffff;
+  --surface:      #ffffff;
+  --surface-2:    #f3f3f7;
+  --border:       #e6e6ee;
+  --border-strong:#d0d0dc;
+  --text:         #1a1a25;
+  --text-soft:    #5a5a72;
+  --text-muted:   #8585a0;
+  --accent:       #0078d4;
+  --accent-2:     #8661c5;
+  --accent-3:     #00B294;
+  --accent-grad:  linear-gradient(135deg,#0078d4 0%,#8661c5 50%,#e3008c 100%);
+  --shadow-sm:    0 1px 2px rgba(20,20,40,.04), 0 1px 1px rgba(20,20,40,.03);
+  --shadow:       0 4px 12px rgba(20,20,40,.06), 0 2px 4px rgba(20,20,40,.04);
+  --shadow-lg:    0 24px 48px rgba(20,20,40,.10), 0 8px 16px rgba(20,20,40,.06);
+  --radius:       14px;
+  --radius-sm:    8px;
+  --radius-lg:    24px;
+  --font:         "Segoe UI Variable","Segoe UI",-apple-system,BlinkMacSystemFont,system-ui,sans-serif;
+}
+
+[data-theme="dark"] {
+  --bg:           #0d0d14;
+  --bg-alt:       #14141d;
+  --bg-band:      #0f0f17;
+  --surface:      #181822;
+  --surface-2:    #21212d;
+  --border:       #2a2a38;
+  --border-strong:#3a3a4a;
+  --text:         #f0f0f5;
+  --text-soft:    #b8b8c8;
+  --text-muted:   #8585a0;
+  --accent:       #4cc2ff;
+  --accent-2:     #b4a0ff;
+  --accent-3:     #4dd8b6;
+  --shadow-sm:    0 1px 2px rgba(0,0,0,.4);
+  --shadow:       0 4px 12px rgba(0,0,0,.5), 0 2px 4px rgba(0,0,0,.3);
+  --shadow-lg:    0 24px 48px rgba(0,0,0,.6), 0 8px 16px rgba(0,0,0,.4);
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; scroll-padding-top: 80px; }
+body {
+  margin: 0;
+  font-family: var(--font);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+.wrap { max-width: 1200px; margin: 0 auto; padding: 0 24px; }
+
+/* ============================================================ HEADER */
+.site-header {
+  position: sticky; top: 0; z-index: 50;
+  background: color-mix(in srgb, var(--bg) 85%, transparent);
+  backdrop-filter: saturate(180%) blur(20px);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  border-bottom: 1px solid var(--border);
+}
+.site-header .wrap {
+  display: flex; align-items: center; gap: 24px;
+  height: 64px;
+}
+.brand {
+  display: flex; align-items: center; gap: 10px;
+  font-weight: 700; color: var(--text); font-size: 17px;
+}
+.brand:hover { text-decoration: none; }
+.brand-mark { font-size: 22px; }
+.brand-by { font-weight: 400; color: var(--text-muted); font-size: 13px; }
+.primary-nav { display: flex; gap: 22px; margin-left: auto; align-items: center; }
+.primary-nav a {
+  color: var(--text-soft);
+  font-size: 14px; font-weight: 500;
+  padding: 6px 2px;
+  position: relative;
+}
+.primary-nav a:hover { color: var(--text); text-decoration: none; }
+.primary-nav a:not(.nav-cta)::after {
+  content: ""; position: absolute; left: 0; bottom: 0;
+  width: 0; height: 2px;
+  background: var(--accent-grad);
+  transition: width .25s ease;
+}
+.primary-nav a:not(.nav-cta):hover::after { width: 100%; }
+.nav-cta {
+  background: var(--text); color: var(--bg) !important;
+  padding: 8px 14px !important; border-radius: 8px;
+  font-weight: 600 !important;
+}
+.nav-cta:hover { background: var(--accent); text-decoration: none; }
+.theme-toggle {
+  background: var(--surface-2); border: 1px solid var(--border);
+  color: var(--text); width: 36px; height: 36px;
+  border-radius: 50%; cursor: pointer; font-size: 16px;
+  display: flex; align-items: center; justify-content: center;
+}
+.theme-toggle:hover { background: var(--surface); border-color: var(--border-strong); }
+
+/* ============================================================ HERO */
+.hero {
+  position: relative;
+  padding: 96px 0 80px;
+  overflow: hidden;
+  background: var(--bg);
+}
+.hero-bg {
+  position: absolute; inset: 0; pointer-events: none;
+  overflow: hidden;
+}
+.orb {
+  position: absolute; border-radius: 50%;
+  filter: blur(80px); opacity: .35;
+  animation: float 18s ease-in-out infinite;
+}
+.orb-1 { width: 480px; height: 480px; background: #0078d4; top: -120px; left: -80px; }
+.orb-2 { width: 380px; height: 380px; background: #8661c5; top: 60px; right: -100px; animation-delay: -6s; }
+.orb-3 { width: 320px; height: 320px; background: #e3008c; bottom: -120px; left: 40%; animation-delay: -12s; }
+[data-theme="dark"] .orb { opacity: .18; }
+@keyframes float {
+  0%, 100% { transform: translate(0,0); }
+  50% { transform: translate(40px,-30px); }
+}
+
+.hero-wrap { position: relative; z-index: 1; text-align: center; }
+.hero-eyebrow {
+  display: inline-block;
+  font-size: 13px; font-weight: 600;
+  letter-spacing: .08em; text-transform: uppercase;
+  color: var(--text-soft);
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg) 70%, transparent);
+  backdrop-filter: blur(8px);
+  border-radius: 100px;
+  margin-bottom: 28px;
+}
+.hero-title {
+  font-size: clamp(36px, 5.5vw, 64px);
+  line-height: 1.05;
+  letter-spacing: -.02em;
+  font-weight: 700;
+  margin: 0 auto 24px;
+  max-width: 900px;
+}
+.hero-title em { font-style: italic; color: var(--text-soft); font-weight: 500; }
+.grad {
+  background: var(--accent-grad);
+  -webkit-background-clip: text; background-clip: text;
+  color: transparent;
+  display: inline-block;
+}
+.hero-sub {
+  font-size: 19px;
+  color: var(--text-soft);
+  max-width: 720px; margin: 0 auto 40px;
+}
+.hero-ctas { display: flex; gap: 12px; justify-content: center; margin-bottom: 64px; flex-wrap: wrap; }
+.btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 14px 24px;
+  border-radius: 10px;
+  font-weight: 600; font-size: 15px;
+  cursor: pointer; border: 1px solid transparent;
+  transition: transform .15s ease, box-shadow .15s ease, background .15s ease;
+}
+.btn-primary {
+  background: var(--text); color: var(--bg);
+  box-shadow: var(--shadow);
+}
+.btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-lg);
+  text-decoration: none;
+  background: var(--accent);
+}
+.btn-ghost {
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border-strong);
+}
+.btn-ghost:hover { background: var(--surface-2); text-decoration: none; }
+
+.hero-stats {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  gap: 24px; max-width: 760px; margin: 0 auto;
+  padding-top: 32px; border-top: 1px solid var(--border);
+}
+.hero-stats > div { text-align: center; }
+.hero-stats strong {
+  display: block; font-size: 32px; font-weight: 700;
+  background: var(--accent-grad);
+  -webkit-background-clip: text; background-clip: text; color: transparent;
+}
+.hero-stats span {
+  display: block; font-size: 12px; color: var(--text-muted);
+  text-transform: uppercase; letter-spacing: .08em; margin-top: 4px;
+}
+
+/* ============================================================ BANDS */
+.band { padding: 88px 0; }
+.band:nth-of-type(even) { background: var(--bg-alt); }
+.section-title {
+  font-size: clamp(28px, 3vw, 40px);
+  font-weight: 700; letter-spacing: -.015em;
+  margin: 0 0 12px;
+}
+.section-lead {
+  font-size: 17px; color: var(--text-soft);
+  max-width: 700px; margin: 0 0 40px;
+}
+
+/* ============================================================ JOURNEY */
+.journey {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr auto 1fr auto 1fr;
+  align-items: stretch; gap: 16px;
+}
+.journey-step {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 24px;
+  box-shadow: var(--shadow-sm);
+  transition: transform .2s ease, box-shadow .2s ease;
+}
+.journey-step:hover { transform: translateY(-3px); box-shadow: var(--shadow); }
+.step-num {
+  width: 32px; height: 32px; border-radius: 50%;
+  background: var(--accent-grad); color: white;
+  display: flex; align-items: center; justify-content: center;
+  font-weight: 700; margin-bottom: 12px;
+}
+.step-name { font-weight: 700; font-size: 16px; margin-bottom: 6px; }
+.step-desc { color: var(--text-soft); font-size: 14px; line-height: 1.5; }
+.journey-arrow {
+  align-self: center;
+  color: var(--text-muted); font-size: 20px;
+}
+@media (max-width: 900px) {
+  .journey { grid-template-columns: 1fr; }
+  .journey-arrow { display: none; }
+}
+
+/* ============================================================ PICKER */
+.picker {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 40px;
+  box-shadow: var(--shadow);
+}
+.picker-question { margin-bottom: 32px; }
+.picker-question:last-of-type { margin-bottom: 0; }
+.picker-label {
+  display: block; font-weight: 600; font-size: 15px;
+  margin-bottom: 12px;
+}
+.picker-options { display: flex; flex-wrap: wrap; gap: 8px; }
+.chip {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 10px 18px;
+  border-radius: 100px;
+  font-size: 14px; font-weight: 500;
+  cursor: pointer;
+  transition: all .15s ease;
+  font-family: inherit;
+}
+.chip:hover { background: var(--surface); border-color: var(--border-strong); transform: translateY(-1px); }
+.chip.selected {
+  background: var(--text);
+  color: var(--bg);
+  border-color: var(--text);
+}
+.picker-result {
+  margin-top: 32px;
+  padding-top: 32px;
+  border-top: 2px dashed var(--border);
+  text-align: center;
+}
+.picker-result-label {
+  font-size: 12px; text-transform: uppercase;
+  letter-spacing: .1em; color: var(--text-muted);
+  margin-bottom: 16px;
+}
+.picker-result-card {
+  background: var(--bg);
+  border: 2px solid var(--accent);
+  border-radius: var(--radius);
+  padding: 24px;
+  margin-bottom: 20px;
+  text-align: left;
+}
+.picker-result-card h3 { margin: 0 0 8px; font-size: 22px; }
+.picker-result-card p { margin: 0 0 16px; color: var(--text-soft); }
+.picker-result-card .picker-cta {
+  display: inline-flex; gap: 8px; align-items: center;
+  font-weight: 600;
+}
+
+/* ============================================================ TOOLKIT CARDS */
+.filter-bar {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  margin-bottom: 32px;
+}
+.filter-label { font-size: 14px; color: var(--text-muted); margin-right: 8px; }
+.filter-pill {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-soft);
+  padding: 8px 16px;
+  border-radius: 100px;
+  font-size: 13px; font-weight: 500;
+  cursor: pointer; font-family: inherit;
+  transition: all .15s ease;
+}
+.filter-pill:hover { color: var(--text); border-color: var(--border-strong); }
+.filter-pill.active {
+  background: var(--text); color: var(--bg);
+  border-color: var(--text);
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 24px;
+}
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 28px;
+  display: flex; flex-direction: column;
+  transition: transform .2s ease, box-shadow .2s ease, border-color .2s ease;
+  position: relative;
+  overflow: hidden;
+}
+.card::before {
+  content: ""; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--card-accent, var(--accent));
+  opacity: 0; transition: opacity .2s ease;
+}
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-lg);
+  border-color: var(--border-strong);
+}
+.card:hover::before { opacity: 1; }
+.card-icon {
+  width: 48px; height: 48px;
+  border-radius: 12px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 24px;
+  background: color-mix(in srgb, var(--card-accent, var(--accent)) 12%, transparent);
+  color: var(--card-accent, var(--accent));
+  margin-bottom: 18px;
+}
+.card-tags { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 12px; }
+.card-tag {
+  font-size: 11px; font-weight: 600;
+  letter-spacing: .05em; text-transform: uppercase;
+  color: var(--text-muted);
+  padding: 3px 10px;
+  border: 1px solid var(--border);
+  border-radius: 100px;
+}
+.card-title { font-size: 20px; font-weight: 700; margin: 0 0 8px; }
+.card-sub { color: var(--text-soft); font-size: 15px; margin: 0 0 20px; flex: 1; line-height: 1.5; }
+.card-meta {
+  display: flex; gap: 16px; font-size: 12px; color: var(--text-muted);
+  padding: 14px 0; border-top: 1px solid var(--border);
+  margin-bottom: 16px;
+}
+.card-meta strong { color: var(--text); display: block; font-size: 14px; font-weight: 600; }
+.card-links { display: flex; gap: 8px; flex-wrap: wrap; }
+.card-links a {
+  font-size: 13px; font-weight: 600;
+  padding: 8px 14px;
+  border-radius: 8px;
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  transition: all .15s ease;
+}
+.card-links a:hover { background: var(--text); color: var(--bg); text-decoration: none; border-color: var(--text); }
+.card-links a.primary { background: var(--text); color: var(--bg); border-color: var(--text); }
+.card-links a.primary:hover { background: var(--accent); border-color: var(--accent); }
+
+/* card accent colors via JS-applied --card-accent */
+
+/* ============================================================ DATA SOURCES */
+.data-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 20px;
+}
+.data-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 28px;
+  transition: transform .2s ease, box-shadow .2s ease;
+}
+.data-card:hover { transform: translateY(-2px); box-shadow: var(--shadow); }
+.data-icon {
+  width: 44px; height: 44px;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--ic, var(--accent)) 14%, transparent);
+  color: var(--ic, var(--accent));
+  display: flex; align-items: center; justify-content: center;
+  font-size: 22px; margin-bottom: 16px;
+}
+.data-card h3 { margin: 0 0 8px; font-size: 18px; }
+.data-card p { color: var(--text-soft); font-size: 14px; margin: 0 0 16px; }
+.data-tools { display: flex; flex-wrap: wrap; gap: 6px; }
+.tool-tag {
+  font-size: 12px;
+  padding: 4px 10px;
+  background: var(--surface-2);
+  border-radius: 100px;
+  color: var(--text-soft);
+}
+
+/* ============================================================ STORIES */
+.quotes {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+}
+.quote {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--accent);
+  border-radius: var(--radius);
+  margin: 0;
+  padding: 28px;
+  font-size: 16px; line-height: 1.6;
+}
+.quote p { margin: 0 0 14px; font-style: italic; }
+.quote cite { color: var(--text-muted); font-style: normal; font-size: 14px; }
+
+/* ============================================================ TEAM */
+.two-col {
+  display: grid; grid-template-columns: 1.4fr 1fr; gap: 48px;
+  align-items: start;
+}
+@media (max-width: 800px) { .two-col { grid-template-columns: 1fr; } }
+.team-ctas { display: flex; gap: 12px; margin-top: 24px; flex-wrap: wrap; }
+.team-callout {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 28px;
+}
+.team-callout h3 { margin: 0 0 16px; }
+.engagement-list { list-style: none; padding: 0; margin: 0; }
+.engagement-list li {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-soft);
+}
+.engagement-list li:last-child { border-bottom: none; }
+.engagement-list strong { color: var(--text); display: inline-block; min-width: 160px; }
+
+/* ============================================================ FOOTER */
+.site-footer {
+  background: var(--bg-alt);
+  border-top: 1px solid var(--border);
+  padding: 64px 0 32px;
+}
+.footer-cols {
+  display: grid; grid-template-columns: 1.5fr 1fr 1fr 1fr;
+  gap: 40px; margin-bottom: 48px;
+}
+@media (max-width: 800px) { .footer-cols { grid-template-columns: 1fr 1fr; } }
+.footer-brand { font-weight: 700; font-size: 18px; margin-bottom: 4px; }
+.footer-sub { color: var(--text-muted); font-size: 13px; }
+.footer-heading {
+  font-weight: 700; font-size: 14px;
+  margin-bottom: 14px; color: var(--text);
+}
+.footer-cols a {
+  display: block; padding: 4px 0;
+  color: var(--text-soft); font-size: 14px;
+}
+.footer-cols a:hover { color: var(--accent); text-decoration: none; }
+.footer-fine {
+  border-top: 1px solid var(--border);
+  padding-top: 24px;
+  color: var(--text-muted);
+  font-size: 13px;
+  text-align: center;
+}
+
+/* ============================================================ RESPONSIVE */
+@media (max-width: 700px) {
+  .primary-nav { display: none; }
+  .hero-stats { grid-template-columns: repeat(2,1fr); }
+  .picker { padding: 24px; }
+}


### PR DESCRIPTION
- Interactive 9-tool toolkit grid with data-source filters
- 3-question 'Find My Tool' picker with score-based recommendation
- Light + dark theme with system preference detection
- Microsoft Fluent-inspired design, no external dependencies
- Ready to enable Pages: Settings -> Pages -> main / /docs