### PR TITLE
Add Agent Evaluator, and thumbs up/down on every report card

### DIFF
--- a/docs/explore-reports/app.js
+++ b/docs/explore-reports/app.js
@@ -592,21 +592,23 @@ const TOOLS = [
     },
   },
   {
-    id: 'studio-lens',
-    question: "How do my Copilot Studio agents perform — quality, containment, transcripts, and message-credit cost?",
-    title: "StudioLens for Copilot Studio",
-    icon: "🔬",
+    id: 'agent-evaluator',
+    question: "How well are my Copilot Studio agents performing — what do they resolve, what do people ask for, and what does it cost?",
+    title: "Agent Evaluator for Copilot Studio",
+    icon: "🔎",
     accent: "#e3008c",
     category: "usage-intelligence",
     tier: "specialty",
+    isNew: true,
     measures: ["agents","impact"],
     source: "Copilot Studio transcripts (Dataverse) + Power Platform admin center",
     sourceKey: "Dataverse",
-    repo: "https://github.com/Keithland89/StudioLens-for-Copilot-Studio",
-    download: "https://github.com/Keithland89/StudioLens-for-Copilot-Studio/archive/refs/heads/main.zip",
-    preview: "https://raw.githubusercontent.com/Keithland89/StudioLens-for-Copilot-Studio/main/assets/studiolens-demo.gif",
-    blurb: "Business Value Advisory Power BI template for deep Copilot Studio agent evaluation — sessions, turns, errors, sub-agent calls, quality & performance, topics, knowledge files, user feedback, and Power Platform message-credit consumption. Dataverse Direct and Fabric deployment paths.",
-    meta: { audience: "Agent makers, Studio admins, FinOps", license: "Dataverse read (+ Fabric for credit pages)", time: "~45 min" },
+    repo: "https://github.com/microsoft/AgentEvaluator-for-Copilot-Studio",
+    download: "https://github.com/microsoft/AgentEvaluator-for-Copilot-Studio/archive/refs/heads/main.zip",
+    preview: "https://raw.githubusercontent.com/microsoft/AgentEvaluator-for-Copilot-Studio/main/assets/agent-evaluator-demo.gif",
+    demoVideo: "https://github.com/microsoft/AgentEvaluator-for-Copilot-Studio/raw/main/media/AgentEvaluator-Demo.mp4",
+    blurb: "One Power BI template for deep Copilot Studio agent evaluation — sessions, turns, errors, sub-agent calls, quality & performance, topics, knowledge grounding, CSAT and message-credit consumption. Reads the conversation transcripts themselves, so every number has a real conversation behind it. Local CSV, Dataverse and Fabric paths, chosen by one parameter; sample data included.",
+    meta: { audience: "Agent makers, Studio admins, FinOps", license: "Dataverse read (+ Fabric for credit pages)", time: "~2 min on sample data, ~45 min on your own" },
     requirements: {
       roles: [
         { label: "Dataverse read (Copilot Studio transcripts)", url: "https://learn.microsoft.com/microsoft-copilot-studio/" },
@@ -614,7 +616,7 @@ const TOOLS = [
       ],
       software: [
         { label: "Power BI Desktop (May 2024+)", url: "https://www.microsoft.com/download/details.aspx?id=58494" },
-        { label: "Dataverse environment (+ Fabric capacity for message-credit pages)" }
+        { label: "Nothing at all for the sample-data path; Dataverse environment or Fabric capacity for your own data" }
       ]
     },
   },

--- a/docs/explore-reports/index.html
+++ b/docs/explore-reports/index.html
@@ -86,8 +86,8 @@
   </script>
 
   <!-- SEO:end -->
-  <link rel="stylesheet" href="../styles.css?v=7a506cda" />
-  <link rel="stylesheet" href="styles.css?v=d2b66486" />
+  <link rel="stylesheet" href="../styles.css?v=2e88898a" />
+  <link rel="stylesheet" href="styles.css?v=2e88898a" />
   <link rel="preconnect" href="https://github.com" />
   <link rel="preconnect" href="https://opengraph.githubassets.com" />
   <!-- Microsoft Clarity -->
@@ -103,6 +103,7 @@
   <link rel="stylesheet" href="../palette.css?v=936728fb" />
   <script src="../palette.js" defer></script>
   <script src="../nudges.js" defer></script>
+  <script src="../votes.js?v=ebde7b5a" defer></script>
 </head>
 <body>
 <a class="ah-skip" href="#top">Skip to main content</a>

--- a/docs/explore-reports/styles.css
+++ b/docs/explore-reports/styles.css
@@ -796,3 +796,7 @@
 .btn-primary, .cta.primary, a.primary, .primary-btn {
   background: var(--accent);
 }
+
+/* votes — inherits ../styles.css, but this page's cells need the row layout */
+td.col-actions { white-space: nowrap; }
+td.col-actions .ah-vote { margin-left: 0; margin-right: 6px; vertical-align: middle; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,7 +37,7 @@
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"Analytics Hub","url":"https://microsoft.github.io/Analytics-Hub/","publisher":{"@type":"Organization","name":"Microsoft"},"potentialAction":{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://microsoft.github.io/Analytics-Hub/explore-reports/?q={search_term_string}"},"query-input":"required name=search_term_string"}}</script>
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Analytics Hub","applicationCategory":"BusinessApplication","operatingSystem":"Web, Power BI Desktop, Power BI Service","url":"https://microsoft.github.io/Analytics-Hub/","author":{"@type":"Organization","name":"Microsoft"},"offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"description":"Eleven open-source Power BI templates and exporters to measure Microsoft Copilot adoption, sentiment, ROI, and agent usage."}</script>
   <!-- SEO:end -->
-  <link rel="stylesheet" href="styles.css?v=7a506cda" />
+  <link rel="stylesheet" href="styles.css?v=2e88898a" />
   <link rel="preconnect" href="https://github.com" />
   <!-- Microsoft Clarity -->
   <script type="text/javascript">
@@ -52,6 +52,7 @@
   <link rel="stylesheet" href="./palette.css?v=936728fb" />
   <script src="./palette.js" defer></script>
   <script src="./nudges.js" defer></script>
+  <script src="./votes.js?v=ebde7b5a" defer></script>
 </head>
 <body>
 <a class="ah-skip" href="#top">Skip to main content</a>
@@ -161,8 +162,8 @@
 <section class="band flagship-band" id="flagship">
   <div class="wrap">
     <p class="eyebrow center">Recently added</p>
-    <h2 class="section-title center">Two new dashboards, built to work together</h2>
-    <p class="section-lead center">One measures whether Copilot is landing. The other tracks what it costs. Run either on its own, or both for the value and the spend side by side. Sample data ships with each, so you can look before setting anything up.</p>
+    <h2 class="section-title center">Three new dashboards, built to work together</h2>
+    <p class="section-lead center">One measures whether Copilot is landing. One tracks what it costs. One goes deep on the agents you have built in Copilot Studio. Run any on its own, or together for value, spend and agent quality side by side. Sample data ships with each, so you can look before setting anything up.</p>
 
     <div class="flagship-grid">
 
@@ -218,6 +219,35 @@
           <div class="flagship-ctas">
             <a class="btn btn-primary" href="https://github.com/microsoft/ConsumptionCentral-for-Microsoft-Copilot" target="_blank" rel="noopener">Get Consumption Central ↗</a>
             <a class="btn btn-ghost" href="cowork-billing/">Cost resources →</a>
+          </div>
+        </div>
+      </article>
+
+      <article class="flagship-card" style="--c:#e3008c;">
+        <div class="flagship-media">
+          <video controls preload="metadata" playsinline aria-label="Agent Evaluator two-minute demo">
+            <source src="https://github.com/microsoft/AgentEvaluator-for-Copilot-Studio/raw/main/media/AgentEvaluator-Demo.mp4" type="video/mp4" />
+            <p>Your browser cannot play this video.
+              <a href="https://github.com/microsoft/AgentEvaluator-for-Copilot-Studio/raw/main/media/AgentEvaluator-Demo.mp4">Download it instead</a>.</p>
+          </video>
+        </div>
+        <div class="flagship-body">
+          <p class="flagship-eyebrow">New · agent quality</p>
+          <h3>Agent Evaluator</h3>
+          <p class="flagship-desc">
+            Goes deep on the agents you have actually built in Copilot Studio —
+            what they resolve, what people ask them for, and where the next
+            improvement is. Reads the conversation transcripts themselves, so
+            every number has a real conversation behind it.
+          </p>
+          <ul class="flagship-points">
+            <li>Resolution and containment, with designed handoffs counted as success</li>
+            <li>Topics, knowledge grounding, CSAT and a ranked fix list</li>
+            <li>Local CSV, Dataverse and Fabric paths — one template</li>
+          </ul>
+          <div class="flagship-ctas">
+            <a class="btn btn-primary" href="https://github.com/microsoft/AgentEvaluator-for-Copilot-Studio" target="_blank" rel="noopener">Get Agent Evaluator ↗</a>
+            <a class="btn btn-ghost" href="explore-reports/#agent-evaluator">See the detail →</a>
           </div>
         </div>
       </article>
@@ -455,13 +485,13 @@
       </article>
       <article class="rf-card" data-cat="usage-intelligence" style="--c:#e3008c">
         <div class="rf-top">
-          <span class="rf-chip">Usage &amp; Intelligence</span>
+          <span class="rf-chip">Usage &amp; Intelligence</span><span class="rf-new">New</span>
         </div>
-        <h3 class="rf-title">StudioLens for Copilot Studio</h3>
-        <p class="rf-blurb">Business Value Advisory Power BI template for deep Copilot Studio agent evaluation — sessions, turns, errors, sub-agent calls, quality &amp; performance, </p>
+        <h3 class="rf-title">Agent Evaluator for Copilot Studio</h3>
+        <p class="rf-blurb">One Power BI template for deep Copilot Studio agent evaluation — sessions, turns, errors, sub-agent calls, quality &amp; performance, topics, </p>
         <div class="rf-foot">
           <span class="rf-src">Copilot Studio transcripts (Dataverse) + Power Platform admin center</span>
-          <a class="rf-cta" href="https://github.com/Keithland89/StudioLens-for-Copilot-Studio" target="_blank" rel="noopener">View <span aria-hidden="true">↗</span></a>
+          <a class="rf-cta" href="https://github.com/microsoft/AgentEvaluator-for-Copilot-Studio" target="_blank" rel="noopener">View <span aria-hidden="true">↗</span></a>
         </div>
       </article>
       <article class="rf-card" data-cat="adoption-behavior" style="--c:#00B294">

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1921,3 +1921,34 @@ main .team-hero .lede {
 .cb-limit-source { font-size: .9em; opacity: .78; line-height: 1.6; }
 [data-theme="dark"] .cb-limit-card { background: #1e1e24; border-color: rgba(255,255,255,0.12); }
 [data-theme="dark"] .cb-limit-card blockquote { background: rgba(255,255,255,0.05); }
+
+/* ---------------------------------------------------------------- votes
+   Thumbs up / down on each report card, matching Copilot Analytics Labs.
+   Sits inside .rf-foot between the source label and the View link, so it
+   inherits the card's own accent colour via --c. */
+.ah-vote {
+  display: inline-flex; align-items: center; gap: 2px;
+  flex: none; margin-left: auto; margin-right: 8px;
+}
+.ah-vote.is-pending { opacity: .55; }
+.ah-vote-btn {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 3px 7px; border: none; border-radius: 6px;
+  background: transparent; color: var(--text-muted);
+  font: inherit; font-size: 12px; font-weight: 600; line-height: 1;
+  cursor: pointer; transition: background-color .12s, color .12s;
+}
+.ah-vote-btn:hover { background: var(--surface-2, rgba(127,127,127,.12)); color: var(--text); }
+.ah-vote-btn:focus-visible { outline: 2px solid var(--c, var(--accent)); outline-offset: 1px; }
+.ah-vote-btn svg { display: block; }
+.ah-vote-up.is-on   { color: var(--c, var(--accent)); }
+.ah-vote-down.is-on { color: #d13438; }
+.ah-vote-n { font-variant-numeric: tabular-nums; }
+@media (max-width: 520px) { .rf-src { display: none; } }
+
+/* Flagship grid now carries three cards. The base rule reserves a 420px
+   minimum, which only fits two in the 1152px wrap, leaving the third stranded
+   on its own row. Allow a narrower track once there is room for three. */
+@media (min-width: 1100px) {
+  .flagship-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}

--- a/docs/votes.js
+++ b/docs/votes.js
@@ -1,0 +1,240 @@
+/* ============================================================================
+   votes.js — thumbs up / down on every report card
+   ----------------------------------------------------------------------------
+   Mirrors the widget on Copilot Analytics Labs, and talks to the SAME backend
+   so a template shows one set of numbers wherever it appears.
+
+   Labs stores votes in Supabase:
+       read   GET  {SUPABASE}/rest/v1/card_votes?select=card_id,up,down
+       write  POST {SUPABASE}/rest/v1/rpc/apply_vote
+              body {p_card_id, p_up, p_down} -> returns the new {up, down}
+
+   The key below is Supabase's *publishable* (anon) key. It is designed to be
+   public and is already served in the Labs bundle; row-level security, not key
+   secrecy, is what protects the table. Point SUPABASE_URL/KEY at a different
+   project to decouple the two sites.
+
+   If the backend is unreachable the widget still works — counts fall back to
+   localStorage so the page never shows a broken control. That also means a
+   first-time visitor with no network to Supabase sees zeros rather than an
+   error, which is the behaviour Labs has.
+
+   Card ids are prefixed `ah-` so Hub rows cannot collide with Labs rows in the
+   shared table.
+   ========================================================================== */
+(function () {
+  'use strict';
+
+  var SUPABASE_URL = 'https://hvrstvxgjtjqzoiucsfa.supabase.co';
+  var SUPABASE_KEY = 'sb_publishable_h3R4-v8IEEcLraqzjh4hXQ_YU-FLPpM';
+  var ID_PREFIX    = 'ah-';
+
+  var LS_MY_VOTES = 'ah_card_my_votes';
+  var LS_COUNTS   = 'ah_card_vote_counts';
+
+  var counts = {};        // cardId -> {up, down}
+  var loaded = false;
+
+  // ---------------------------------------------------------------- storage
+  function readLS(key, fallback) {
+    try {
+      var raw = localStorage.getItem(key);
+      if (raw) return JSON.parse(raw);
+    } catch (e) { /* private mode */ }
+    return fallback;
+  }
+
+  function writeLS(key, value) {
+    try { localStorage.setItem(key, JSON.stringify(value)); } catch (e) {}
+  }
+
+  function myVote(id)        { return readLS(LS_MY_VOTES, {})[id] || null; }
+  function setMyVote(id, v)  {
+    var all = readLS(LS_MY_VOTES, {});
+    if (v) all[id] = v; else delete all[id];
+    writeLS(LS_MY_VOTES, all);
+  }
+
+  // ------------------------------------------------------------------ api
+  function headers() {
+    return {
+      'apikey': SUPABASE_KEY,
+      'Authorization': 'Bearer ' + SUPABASE_KEY,
+      'Content-Type': 'application/json'
+    };
+  }
+
+  function loadCounts() {
+    if (loaded) return Promise.resolve();
+    loaded = true;
+    return fetch(SUPABASE_URL + '/rest/v1/card_votes?select=card_id,up,down',
+                 { headers: headers() })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(); })
+      .then(function (rows) {
+        rows.forEach(function (row) {
+          counts[row.card_id] = { up: row.up || 0, down: row.down || 0 };
+        });
+      })
+      .catch(function () {
+        counts = readLS(LS_COUNTS, {});     // offline / blocked
+      });
+  }
+
+  function applyVote(id, dUp, dDown) {
+    return fetch(SUPABASE_URL + '/rest/v1/rpc/apply_vote', {
+      method: 'POST',
+      headers: Object.assign(headers(), { 'Prefer': 'return=representation' }),
+      body: JSON.stringify({ p_card_id: id, p_up: dUp, p_down: dDown })
+    })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(); })
+      .then(function (data) {
+        var row = Array.isArray(data) ? data[0] : data;
+        if (!row) return Promise.reject();
+        return { up: row.up || 0, down: row.down || 0 };
+      })
+      .catch(function () {
+        // keep a local tally so the number the user just changed still moves
+        var local = readLS(LS_COUNTS, {});
+        var cur = local[id] || { up: 0, down: 0 };
+        var next = {
+          up: Math.max(cur.up + dUp, 0),
+          down: Math.max(cur.down + dDown, 0)
+        };
+        local[id] = next;
+        writeLS(LS_COUNTS, local);
+        return next;
+      });
+  }
+
+  // ------------------------------------------------------------------- ui
+  var ICON_UP =
+    '<svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">' +
+    '<path fill="currentColor" d="M6.3 14h5a1.6 1.6 0 0 0 1.56-1.26l1.1-5A1.6 1.6 0 0 0 12.4 5.8H9.9l.36-1.9a1.5 1.5 0 0 0-2.6-1.3L5.3 5.4V14Zm-3.9 0h2V6h-2A1.4 1.4 0 0 0 1 7.4v5.2A1.4 1.4 0 0 0 2.4 14Z"/></svg>';
+  var ICON_DOWN =
+    '<svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">' +
+    '<path fill="currentColor" d="M9.7 2h-5A1.6 1.6 0 0 0 3.14 3.26l-1.1 5A1.6 1.6 0 0 0 3.6 10.2h2.5l-.36 1.9a1.5 1.5 0 0 0 2.6 1.3l2.36-2.8V2Zm3.9 0h-2v8h2A1.4 1.4 0 0 0 15 8.6V3.4A1.4 1.4 0 0 0 13.6 2Z"/></svg>';
+
+  function render(root, id) {
+    var c = counts[id] || { up: 0, down: 0 };
+    var mine = myVote(id);
+    root.querySelector('.ah-vote-up').setAttribute('aria-pressed', mine === 'up');
+    root.querySelector('.ah-vote-down').setAttribute('aria-pressed', mine === 'down');
+    root.querySelector('.ah-vote-up').classList.toggle('is-on', mine === 'up');
+    root.querySelector('.ah-vote-down').classList.toggle('is-on', mine === 'down');
+    root.querySelector('.ah-vote-up .ah-vote-n').textContent = c.up;
+    root.querySelector('.ah-vote-down .ah-vote-n').textContent = c.down;
+  }
+
+  function cast(root, id, dir) {
+    var mine = myVote(id);
+    var dUp = 0, dDown = 0, next;
+
+    if (mine === dir) {                 // clicking again retracts
+      next = null;
+      if (dir === 'up') dUp = -1; else dDown = -1;
+    } else {
+      next = dir;
+      if (dir === 'up') dUp = 1; else dDown = 1;
+      if (mine === 'up') dUp -= 1;
+      else if (mine === 'down') dDown -= 1;
+    }
+
+    var cur = counts[id] || { up: 0, down: 0 };
+    counts[id] = {
+      up: Math.max(cur.up + dUp, 0),
+      down: Math.max(cur.down + dDown, 0)
+    };
+    setMyVote(id, next);
+    render(root, id);                   // optimistic
+
+    root.classList.add('is-pending');
+    applyVote(id, dUp, dDown).then(function (server) {
+      counts[id] = server;
+      render(root, id);
+    }).then(function () {
+      root.classList.remove('is-pending');
+    });
+  }
+
+  function widget(id) {
+    var el = document.createElement('div');
+    el.className = 'ah-vote';
+    el.setAttribute('role', 'group');
+    el.setAttribute('aria-label', 'Was this useful?');
+    el.innerHTML =
+      '<button type="button" class="ah-vote-btn ah-vote-up" aria-label="Thumbs up">' +
+        ICON_UP + '<span class="ah-vote-n">0</span></button>' +
+      '<button type="button" class="ah-vote-btn ah-vote-down" aria-label="Thumbs down">' +
+        ICON_DOWN + '<span class="ah-vote-n">0</span></button>';
+
+    el.querySelector('.ah-vote-up')
+      .addEventListener('click', function (e) { e.preventDefault(); cast(el, id, 'up'); });
+    el.querySelector('.ah-vote-down')
+      .addEventListener('click', function (e) { e.preventDefault(); cast(el, id, 'down'); });
+    return el;
+  }
+
+  // Derive a stable id from the card's repo link, so a card keeps its votes
+  // even if its title or position changes — and so the same template shows the
+  // same count on the home page and in the explore-reports table.
+  function idFor(card) {
+    var a = card.querySelector('a[href*="github.com/"]');
+    if (a) {
+      var m = a.getAttribute('href').match(/github\.com\/[^/]+\/([^/?#]+)/i);
+      if (m) return ID_PREFIX + m[1].toLowerCase();
+    }
+    var t = card.querySelector('.rf-title, h3, .tool-chip');
+    return ID_PREFIX + (t ? t.textContent.trim().toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') : 'unknown');
+  }
+
+  function attach(host, anchorBefore) {
+    if (host.querySelector('.ah-vote')) return;
+    var id = idFor(host.closest('tr') || host);
+    var w = widget(id);
+    if (anchorBefore) host.insertBefore(w, anchorBefore);
+    else host.appendChild(w);
+    render(w, id);
+  }
+
+  function mount() {
+    var cards = document.querySelectorAll('.rf-card');
+    var rows = document.querySelectorAll('td.col-actions');
+    if (!cards.length && !rows.length) return;
+
+    loadCounts().then(function () {
+      // home page: card grid
+      cards.forEach(function (card) {
+        if (card.querySelector('.ah-vote')) return;
+        var id = idFor(card);
+        var foot = card.querySelector('.rf-foot');
+        var w = widget(id);
+        if (foot) foot.insertBefore(w, foot.querySelector('.rf-cta'));
+        else card.appendChild(w);
+        render(w, id);
+      });
+      // explore-reports: table rows
+      rows.forEach(function (cell) { attach(cell, null); });
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', mount);
+  } else {
+    mount();
+  }
+
+  // Both catalogs render their rows from JS AFTER this script runs, and re-render
+  // on filter and search. A timeout would be a guess; watch the DOM instead and
+  // mount whenever new cards or action cells appear.
+  var scheduled = false;
+  var observer = new MutationObserver(function () {
+    if (scheduled) return;
+    scheduled = true;
+    requestAnimationFrame(function () {
+      scheduled = false;
+      mount();
+    });
+  });
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+})();


### PR DESCRIPTION
AGENT EVALUATOR
The catalog carried this as 'StudioLens for Copilot Studio', pointing at the pre-transfer Keithland89 fork. The repo has since been renamed to microsoft/AgentEvaluator-for-Copilot-Studio (GitHub redirects the old name) and the three path-specific templates were replaced by a single template driven by one Source Mode parameter. Entry renamed and repointed, and the card now carries a demo video and a NEW badge.

Added as a third flagship card on the home page alongside ValueLens and Consumption Central, so the three sit together: one measures whether Copilot is landing, one what it costs, one how the agents themselves perform.

The flagship grid reserved a 420px minimum track, which fits only two cards in the 1152px wrap and stranded the third on its own row. Allowed a narrower track once there is room for three.

VOTES
Thumbs up/down on every report card, matching Copilot Analytics Labs, and talking to the same Supabase backend so a template shows one set of numbers wherever it appears:

    read   GET  /rest/v1/card_votes?select=card_id,up,down
    write  POST /rest/v1/rpc/apply_vote {p_card_id, p_up, p_down}

Ids are derived from each card's repo link and prefixed 'ah-', so Hub rows cannot collide with Labs rows and a card keeps its votes when its title or position changes. Clicking again retracts; switching sides moves the vote. Counts update optimistically, then reconcile with the server response.

If Supabase is unreachable the widget falls back to localStorage rather than showing a broken control.

Both catalogs render their rows from JS after this script runs, and re-render on filter and search, so mounting is driven by a MutationObserver rather than a timeout.