### PR TITLE
Track video plays in Clarity

### DIFF
--- a/docs/EasyMode/index.html
+++ b/docs/EasyMode/index.html
@@ -13,7 +13,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="Easy Mode" />
-  <script src="../clarity-events.js?v=202608181034" defer></script>
+  <script src="../clarity-events.js?v=202609111200" defer></script>
   <link rel="canonical" href="https://microsoft.github.io/Analytics-Hub/EasyMode/" />
   <!-- Hidden page: do not index, do not appear in sitemap -->
   <meta name="robots" content="noindex, nofollow" />

--- a/docs/FinOps-Cowork/app/finops.html
+++ b/docs/FinOps-Cowork/app/finops.html
@@ -12,7 +12,7 @@
       })(window, document, "clarity", "script", "wxb0r23ozh");
     </script>
     <meta name="clarity-page" content="Cowork FinOps" />
-    <script src="../../clarity-events.js?v=202608181034" defer></script>
+    <script src="../../clarity-events.js?v=202609111200" defer></script>
     <link rel="stylesheet" href="styles.css?v=2">
     <style>
         /* FinOps-only presentation bits, built on the shared theme variables. */

--- a/docs/case-studies/index.html
+++ b/docs/case-studies/index.html
@@ -47,7 +47,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="Case Studies" />
-  <script src="../clarity-events.js?v=202608181034" defer></script>
+  <script src="../clarity-events.js?v=202609111200" defer></script>
   <link rel="stylesheet" href="../palette.css?v=936728fb" />
   <script src="../palette.js" defer></script>
   <script src="../nudges.js" defer></script>

--- a/docs/clarity-events.js
+++ b/docs/clarity-events.js
@@ -11,6 +11,7 @@
      5. CTA / button tracking    → "cta: <label>"
      6. Search usage             → "search used"
      7. Engaged dwell            → "engaged 30s"
+     8. Video plays              → "video play: <file>"
 
    Design rules:
      - Event names carry WHAT was clicked, not just that something was.
@@ -197,6 +198,44 @@
       fired = true;
       safeEvent("search used");
     }, { passive: true });
+  })();
+
+  // ---------------------------------------------------- video plays
+  /* Native <video> play buttons live INSIDE the element, so they never reach
+   * the click handler above. Listen for the first "play" of each video and
+   * name it by its source file, so the count answers "how many times was the
+   * ValueLens demo actually started" rather than an anonymous tally.
+   *
+   *   - Capture phase: the "play" event does not bubble.
+   *   - Fires once per <video> per page load (a scrub/pause/resume is the same
+   *     view, not a new one), so the number is "video starts", not "play events".
+   *   - Name is the source file with its extension dropped, bounded and safe. */
+  function videoName(el) {
+    if (!el) return "";
+    var src = el.currentSrc || el.getAttribute("src") || "";
+    if (!src) {
+      var s = el.querySelector && el.querySelector("source[src]");
+      if (s) src = s.getAttribute("src") || "";
+    }
+    if (!src) {
+      var lbl = el.getAttribute("aria-label") || el.getAttribute("title") || "";
+      return cleanLabel(lbl);
+    }
+    var name = fileOf(src).replace(/\.(mp4|webm|ogg|mov|m4v)(\?|#|$)/i, "");
+    return name.slice(0, 60);
+  }
+
+  (function () {
+    var seen = (typeof WeakSet === "function") ? new WeakSet() : null;
+    document.addEventListener("play", function (ev) {
+      try {
+        var v = ev.target;
+        if (!v || !v.tagName || v.tagName !== "VIDEO") return;
+        if (seen) { if (seen.has(v)) return; seen.add(v); }
+        var name = videoName(v);
+        safeEvent(name ? "video play: " + name : "video play");
+      } catch (e) { /* never break the page */ }
+    }, true);
   })();
 
   // ---------------------------------------------------- engaged dwell

--- a/docs/community/index.html
+++ b/docs/community/index.html
@@ -27,7 +27,7 @@
 
   <link rel="stylesheet" href="../styles.css" />
   <link rel="stylesheet" href="../palette.css" />
-  <script src="../clarity-events.js?v=202608181034" defer></script>
+  <script src="../clarity-events.js?v=202609111200" defer></script>
   <script src="../palette.js" defer></script>
   <script src="../nudges.js" defer></script>
   <script src="../poll.js" defer></script>

--- a/docs/compare/ai-in-one-vs-viva-insights/index.html
+++ b/docs/compare/ai-in-one-vs-viva-insights/index.html
@@ -39,7 +39,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="Compare:AIInOne-vs-Viva" />
-  <script src="../../clarity-events.js?v=202608181034" defer></script>
+  <script src="../../clarity-events.js?v=202609111200" defer></script>
   <link rel="stylesheet" href="../../palette.css?v=936728fb" />
   <script src="../../palette.js" defer></script>
   <script src="../../nudges.js" defer></script>

--- a/docs/compare/chat-intelligence-vs-agent-intelligence/index.html
+++ b/docs/compare/chat-intelligence-vs-agent-intelligence/index.html
@@ -39,7 +39,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="Compare:Chat-vs-Agent" />
-  <script src="../../clarity-events.js?v=202608181034" defer></script>
+  <script src="../../clarity-events.js?v=202609111200" defer></script>
   <link rel="stylesheet" href="../../palette.css?v=936728fb" />
   <script src="../../palette.js" defer></script>
   <script src="../../nudges.js" defer></script>

--- a/docs/compare/index.html
+++ b/docs/compare/index.html
@@ -30,7 +30,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="Compare" />
-  <script src="../clarity-events.js?v=202608181034" defer></script>
+  <script src="../clarity-events.js?v=202609111200" defer></script>
   <link rel="stylesheet" href="../palette.css?v=936728fb" />
   <script src="../palette.js" defer></script>
   <script src="../nudges.js" defer></script>

--- a/docs/cowork-billing/cowork-chargeback/app/index.html
+++ b/docs/cowork-billing/cowork-chargeback/app/index.html
@@ -13,7 +13,7 @@
       })(window, document, "clarity", "script", "wxb0r23ozh");
     </script>
     <meta name="clarity-page" content="Cowork Chargeback" />
-    <script src="../../../clarity-events.js?v=202608181034" defer></script>
+    <script src="../../../clarity-events.js?v=202609111200" defer></script>
     <link rel="stylesheet" href="styles.css?v=5">
     <style>
         .cb-layout { display: grid; grid-template-columns: 290px minmax(0, 1fr); gap: 1.5rem; align-items: start; }

--- a/docs/cowork-billing/cowork-policy-helper/app/index.html
+++ b/docs/cowork-billing/cowork-policy-helper/app/index.html
@@ -13,7 +13,7 @@
       })(window, document, "clarity", "script", "wxb0r23ozh");
     </script>
     <meta name="clarity-page" content="Cowork Policy Helper" />
-    <script src="../../../clarity-events.js?v=202608181034" defer></script>
+    <script src="../../../clarity-events.js?v=202609111200" defer></script>
     <link rel="stylesheet" href="styles.css?v=2">
     <style>
         /* ---- app styles (shared variables from styles.css) ---- */

--- a/docs/cowork-billing/cowork-policy-helper/index.html
+++ b/docs/cowork-billing/cowork-policy-helper/index.html
@@ -13,7 +13,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="Cowork Policy Helper Landing" />
-  <script src="../../clarity-events.js?v=202608181034" defer></script>
+  <script src="../../clarity-events.js?v=202609111200" defer></script>
   <link rel="canonical" href="https://microsoft.github.io/Analytics-Hub/cowork-billing/cowork-policy-helper/" />
   <meta name="theme-color" content="#0078d4" />
   <meta name="color-scheme" content="light dark" />

--- a/docs/cowork-billing/cowork-usage-tracker/app/index.html
+++ b/docs/cowork-billing/cowork-usage-tracker/app/index.html
@@ -13,7 +13,7 @@
       })(window, document, "clarity", "script", "wxb0r23ozh");
     </script>
     <meta name="clarity-page" content="Cowork Usage Tracker" />
-    <script src="../../../clarity-events.js?v=202608181034" defer></script>
+    <script src="../../../clarity-events.js?v=202609111200" defer></script>
     <link rel="stylesheet" href="styles.css?v=3">
     <style>
         /* ---- period-type forced choice ---- */

--- a/docs/cowork-billing/index.html
+++ b/docs/cowork-billing/index.html
@@ -30,7 +30,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="Credit Consumption and Cost" />
-  <script src="../clarity-events.js?v=202608181034" defer></script>
+  <script src="../clarity-events.js?v=202609111200" defer></script>
   <link rel="stylesheet" href="../palette.css?v=936728fb" />
   <script src="../palette.js" defer></script>
   <script src="../nudges.js" defer></script>

--- a/docs/cowork-billing/multi-budget-chargeback/app/index.html
+++ b/docs/cowork-billing/multi-budget-chargeback/app/index.html
@@ -13,7 +13,7 @@
       })(window, document, "clarity", "script", "wxb0r23ozh");
     </script>
     <meta name="clarity-page" content="Multi-Budget Chargeback Report" />
-    <script src="../../../clarity-events.js?v=202608181034" defer></script>
+    <script src="../../../clarity-events.js?v=202609111200" defer></script>
     <link rel="stylesheet" href="styles.css?v=3">
     <style>
         .cb-layout { display: grid; grid-template-columns: 290px minmax(0, 1fr); gap: 1.5rem; align-items: start; }

--- a/docs/data-sources/index.html
+++ b/docs/data-sources/index.html
@@ -47,7 +47,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="Data Sources" />
-  <script src="../clarity-events.js?v=202608181034" defer></script>
+  <script src="../clarity-events.js?v=202609111200" defer></script>
   <link rel="stylesheet" href="../palette.css?v=936728fb" />
   <script src="../palette.js" defer></script>
   <script src="../nudges.js" defer></script>

--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -19,7 +19,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="InternalDemos" />
-  <script src="../clarity-events.js?v=202608181034" defer></script>
+  <script src="../clarity-events.js?v=202609111200" defer></script>
   <link rel="stylesheet" href="../palette.css?v=936728fb" />
   <script src="../palette.js" defer></script>
   <script src="../nudges.js" defer></script>

--- a/docs/explore-reports/index.html
+++ b/docs/explore-reports/index.html
@@ -99,7 +99,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="Explore Reports" />
-  <script src="../clarity-events.js?v=202608181034" defer></script>
+  <script src="../clarity-events.js?v=202609111200" defer></script>
   <link rel="stylesheet" href="../palette.css?v=936728fb" />
   <script src="../palette.js" defer></script>
   <script src="../nudges.js" defer></script>

--- a/docs/faq/index.html
+++ b/docs/faq/index.html
@@ -140,7 +140,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="FAQ" />
-  <script src="../clarity-events.js?v=202608181034" defer></script>
+  <script src="../clarity-events.js?v=202609111200" defer></script>
   <link rel="stylesheet" href="../palette.css?v=936728fb" />
   <script src="../palette.js" defer></script>
   <script src="../nudges.js" defer></script>

--- a/docs/feedback/index.html
+++ b/docs/feedback/index.html
@@ -45,7 +45,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="Feedback" />
-  <script src="../clarity-events.js?v=202608181034" defer></script>
+  <script src="../clarity-events.js?v=202609111200" defer></script>
   <link rel="stylesheet" href="../palette.css?v=936728fb" />
   <script src="../palette.js" defer></script>
   <script src="../nudges.js" defer></script>

--- a/docs/glossary/index.html
+++ b/docs/glossary/index.html
@@ -75,7 +75,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="Glossary" />
-  <script src="../clarity-events.js?v=202608181034" defer></script>
+  <script src="../clarity-events.js?v=202609111200" defer></script>
   <link rel="stylesheet" href="../palette.css?v=936728fb" />
   <script src="../palette.js" defer></script>
   <script src="../nudges.js" defer></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -49,7 +49,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="Home" />
-  <script src="./clarity-events.js?v=202608181034" defer></script>
+  <script src="./clarity-events.js?v=202609111200" defer></script>
   <link rel="stylesheet" href="./palette.css?v=936728fb" />
   <script src="./palette.js" defer></script>
   <script src="./nudges.js" defer></script>

--- a/docs/out-of-the-box/index.html
+++ b/docs/out-of-the-box/index.html
@@ -46,7 +46,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="Overall Reporting Estate" />
-  <script src="../clarity-events.js?v=202608181034" defer></script>
+  <script src="../clarity-events.js?v=202609111200" defer></script>
   <link rel="stylesheet" href="../palette.css?v=936728fb" />
   <script src="../palette.js" defer></script>
   <script src="../nudges.js" defer></script>

--- a/docs/pages-analytics/index.html
+++ b/docs/pages-analytics/index.html
@@ -47,7 +47,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="Pages Analytics" />
-  <script src="../clarity-events.js?v=202608181034" defer></script>
+  <script src="../clarity-events.js?v=202609111200" defer></script>
   <link rel="stylesheet" href="../palette.css?v=936728fb" />
   <script src="../palette.js" defer></script>
   <script src="../nudges.js" defer></script>

--- a/docs/report-ecosystem/index.html
+++ b/docs/report-ecosystem/index.html
@@ -48,7 +48,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="Report Ecosystem" />
-  <script src="../clarity-events.js" defer></script>
+  <script src="../clarity-events.js?v=202609111200" defer></script>
   <link rel="stylesheet" href="../palette.css" />
   <script src="../palette.js" defer></script>
   <script src="../nudges.js" defer></script>

--- a/docs/team/index.html
+++ b/docs/team/index.html
@@ -47,7 +47,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="Team" />
-  <script src="../clarity-events.js?v=202608181034" defer></script>
+  <script src="../clarity-events.js?v=202609111200" defer></script>
   <link rel="stylesheet" href="../palette.css?v=936728fb" />
   <script src="../palette.js" defer></script>
   <script src="../nudges.js" defer></script>

--- a/docs/tools/index.html
+++ b/docs/tools/index.html
@@ -44,7 +44,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="Tools" />
-  <script src="../clarity-events.js?v=202608181034" defer></script>
+  <script src="../clarity-events.js?v=202609111200" defer></script>
   <link rel="stylesheet" href="../palette.css?v=936728fb" />
   <script src="../palette.js" defer></script>
   <script src="../nudges.js" defer></script>

--- a/docs/updates/index.html
+++ b/docs/updates/index.html
@@ -29,7 +29,7 @@
   </script>
   <meta name="clarity-page" content="Updates" />
   <link rel="stylesheet" href="../styles.css" />
-  <script src="../clarity-events.js?v=202608181034" defer></script>
+  <script src="../clarity-events.js?v=202609111200" defer></script>
   <link rel="stylesheet" href="../palette.css?v=936728fb" />
   <script src="../palette.js" defer></script>
   <script src="../nudges.js" defer></script>

--- a/docs/work-request/index.html
+++ b/docs/work-request/index.html
@@ -54,7 +54,7 @@
     })(window, document, "clarity", "script", "wxb0r23ozh");
   </script>
   <meta name="clarity-page" content="Scope AI Tasks" />
-  <script src="../clarity-events.js?v=202608181034" defer></script>
+  <script src="../clarity-events.js?v=202609111200" defer></script>
   <link rel="stylesheet" href="../palette.css?v=936728fb" />
   <script src="../palette.js" defer></script>
   <script src="../nudges.js" defer></script>


### PR DESCRIPTION
## What
Adds video-play tracking to the shared `clarity-events.js` helper so we can see **how many times each demo video is started**.

## Why
Every video on the site is a native HTML5 `<video>` player. The play button lives *inside* the element, so the existing click handler in `clarity-events.js` never captured it — video engagement was invisible in Clarity.

## How
- Capture-phase `play` listener (the `play` event does not bubble).
- Fires **once per `<video>` per page load** (pause/resume is the same view), so the metric is *video starts*, not raw play events.
- Event name is the source filename with the extension dropped, bounded and safe — e.g. `video play: ValueLens-Demo`, `video play: ConsumptionCentral-Demo`, `video play: AgentEvaluator-Demo`, `video play: AI-in-One-Overview`.
- Loaded on all 27 pages already, so this covers the homepage demos, cowork-billing, the multi-budget modal, the dynamic Explore Reports player, and any future video — no per-page edits.
- Cache-bust `?v=` stamp bumped so browsers fetch the updated helper.

## Testing
Verified in a real browser (stubbed `window.clarity`): a play fires exactly one correctly-named event; repeated play events stay at 1 (dedupe works). `node --check` passes.

Counts appear in Clarity under **Custom events** as `video play: <name>`.